### PR TITLE
FIX: Update fnirt outputs for warped_file log_file to cwd

### DIFF
--- a/nipype/interfaces/fsl/preprocess.py
+++ b/nipype/interfaces/fsl/preprocess.py
@@ -1160,7 +1160,7 @@ class FNIRT(FSLCommand):
                 if suffix.endswith('.txt'):
                     change_ext = False
                 if isdefined(inval):
-                    outputs[key] = inval
+                    outputs[key] = os.path.abspath(inval)
                 else:
                     outputs[key] = self._gen_fname(
                         self.inputs.in_file,


### PR DESCRIPTION
<!--

Pull-request guidelines
-----------------------

1. If you would like to list yourself as a Nipype contributor and your name is not mentioned please modify .zenodo.json file.
2. By submitting this request you acknowledge that your contributions are available under the Apache 2 license.
3. Use a descriptive prefix for your PR: ENH (enhancement), FIX, TST, DOC, STY, REF (refactor), WIP (Work in progress)
4. Run `make check-before-commit` before submitting the PR.

-->
## Summary
<!-- Please reference any related issue and use fixes/close to automatically
close them, if pertinent -->
Issue regarding the fix: https://github.com/nipy/nipype/issues/2899

## List of changes proposed in this PR (pull-request)
<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->
* When warped_file or log_file input is set, will append the new name to the current working directory.

## Acknowledgment

- [x] \(Mandatory\) I acknowledge that this contribution will be available under the Apache 2 license.
